### PR TITLE
ci: Enable additional check

### DIFF
--- a/.github/workflows/commit-check.yaml
+++ b/.github/workflows/commit-check.yaml
@@ -37,4 +37,12 @@ jobs:
       uses: tim-actions/commit-body-check@d2e0e8e1f0332b3281c98867c42a2fbe25ad3f15 # v1.0.2
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
+
+    - name: Commit Subject Length Check
+      uses: tim-actions/commit-message-checker-with-regex@d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd # v0.3.1
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+        pattern: '^.{0,75}(\n.*)*$'
+        error: 'Subject too long (max 75)'
+        post_error: ${{ env.error_msg }}
     

--- a/.github/workflows/commit-check.yaml
+++ b/.github/workflows/commit-check.yaml
@@ -45,4 +45,34 @@ jobs:
         pattern: '^.{0,75}(\n.*)*$'
         error: 'Subject too long (max 75)'
         post_error: ${{ env.error_msg }}
+
+    - name: Commit Body Line Length Check
+      uses: tim-actions/commit-message-checker-with-regex@d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd # v0.3.1
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+        # Notes:
+        #
+        # - The subject line is not enforced here (see other check), but has
+        #   to be specified at the start of the regex as the action is passed
+        #   the entire commit message.
+        #
+        # - This check will pass if the commit message only contains a subject
+        #   line, as other body message properties are enforced elsewhere.
+        #
+        # - Body lines *can* be longer than the maximum if they start
+        #   with a non-alphabetic character or if there is no whitespace in
+        #   the line.
+        #
+        #   This allows stack traces, log files snippets, emails, long URLs,
+        #   etc to be specified. Some of these naturally "work" as they start
+        #   with numeric timestamps or addresses. Emails can but quoted using
+        #   the normal ">" character, markdown bullets ("-", "*") are also
+        #   useful for lists of URLs, but it is always possible to override
+        #   the check by simply space indenting the content you need to add.
+        #
+        # - A SoB comment can be any length (as it is unreasonable to penalize
+        #   people with long names/email addresses :)
+        pattern: '(^[^\n]+$|^.+(\n([a-zA-Z].{0,80}|[^a-zA-Z\n].*|[^\s\n]*|Signed-off-by:.*|))+$)'
+        error: 'Body line too long (max 80)'
+        post_error: ${{ env.error_msg }}
     

--- a/.github/workflows/commit-check.yaml
+++ b/.github/workflows/commit-check.yaml
@@ -32,4 +32,9 @@ jobs:
       uses: tim-actions/dco@2fd0504dc0d27b33f542867c300c60840c6dcb20 # master (2020-04-28)
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
+
+    - name: Commit Body Missing Check
+      uses: tim-actions/commit-body-check@d2e0e8e1f0332b3281c98867c42a2fbe25ad3f15 # v1.0.2
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
     


### PR DESCRIPTION
Commit body is mandatory, ci should error out when commit body is empty.